### PR TITLE
Je delete posts

### DIFF
--- a/src/components/posts/ConfirmableDeleteButton.js
+++ b/src/components/posts/ConfirmableDeleteButton.js
@@ -33,7 +33,7 @@ export const ConfirmableDeleteButton = props => {
   )
 
   return (
-    <div className="deleteButtonContainer" onClick={e => e.preventDefault()}>
+    <div className="confirmableDeleteButtonContainer" onClick={e => e.preventDefault()}>
       { isDeleting ? renderConfirmDeleteButtons() : renderInitialDeleteButton() }
     </div>
   )

--- a/src/components/posts/ConfirmableDeleteButton.js
+++ b/src/components/posts/ConfirmableDeleteButton.js
@@ -14,36 +14,27 @@ export const ConfirmableDeleteButton = props => {
     setIsDeleting(false)
   }
 
-  /**
-   * Depending on isDeleting state, either render:
-   *  a) a single button that upon clicking will trigger isDeleting state to be set to true, or
-   *  b) two buttons side-by-side, with one allowing the user to cancel (and thus set isDeleting to false), or confirm their deletion
-   */
-  const renderDeleteButtons = () => {
-    if(isDeleting) {
-      return <>
-        <Button variant="secondary" onClick={() => setIsDeleting(false)}>
-          Cancel
-        </Button>
+  const renderInitialDeleteButton = () => (
+    <Button variant="danger" onClick={() => setIsDeleting(true)}>
+      Delete
+    </Button>
+  )
 
-        <Button variant="danger" onClick={handleConfirmDelete}>
-          Confirm Delete
-        </Button>
-      </>
-    }
+  const renderConfirmDeleteButtons = () => (
+    <>
+      <Button variant="secondary" onClick={() => setIsDeleting(false)}>
+        Cancel
+      </Button>
 
-    else {
-      return (
-        <Button variant="danger" onClick={() => setIsDeleting(true)}>
-          Delete
-        </Button>
-      )
-    }
-  }
+      <Button variant="danger" onClick={handleConfirmDelete}>
+        Confirm Delete
+      </Button>
+    </>
+  )
 
   return (
-    <div className="deleteButtonContainer">
-      { renderDeleteButtons() }
+    <div className="deleteButtonContainer" onClick={e => e.preventDefault()}>
+      { isDeleting ? renderConfirmDeleteButtons() : renderInitialDeleteButton() }
     </div>
   )
 }

--- a/src/components/posts/ConfirmableDeleteButton.js
+++ b/src/components/posts/ConfirmableDeleteButton.js
@@ -1,0 +1,49 @@
+import React, { useState } from "react"
+import Button from "react-bootstrap/Button"
+
+/**
+ * ConfirmableDeleteButton component - renders as a "Delete" button that, when clicked, requires the user to either confirm their deletion before actually deleting, or cancel their deletion.
+ * 
+ * Pass a function implementing whatever you want to happen when the user confirms deletion as props.onDelete.
+ */
+export const ConfirmableDeleteButton = props => {
+  const [ isDeleting, setIsDeleting ] = useState(false)
+
+  const handleConfirmDelete = () => {
+    props.onDelete()
+    setIsDeleting(false)
+  }
+
+  /**
+   * Depending on isDeleting state, either render:
+   *  a) a single button that upon clicking will trigger isDeleting state to be set to true, or
+   *  b) two buttons side-by-side, with one allowing the user to cancel (and thus set isDeleting to false), or confirm their deletion
+   */
+  const renderDeleteButtons = () => {
+    if(isDeleting) {
+      return <>
+        <Button variant="secondary" onClick={() => setIsDeleting(false)}>
+          Cancel
+        </Button>
+
+        <Button variant="danger" onClick={handleConfirmDelete}>
+          Confirm Delete
+        </Button>
+      </>
+    }
+
+    else {
+      return (
+        <Button variant="danger" onClick={() => setIsDeleting(true)}>
+          Delete
+        </Button>
+      )
+    }
+  }
+
+  return (
+    <div className="deleteButtonContainer">
+      { renderDeleteButtons() }
+    </div>
+  )
+}

--- a/src/components/posts/ConfirmableDeleteButton.js
+++ b/src/components/posts/ConfirmableDeleteButton.js
@@ -32,6 +32,10 @@ export const ConfirmableDeleteButton = props => {
     </>
   )
 
+  // this div includes a click handler that calls preventDefault on the event when clicked
+  // this is because one context in which the ConfirmableDeleteButton is used is in the UserPostListItem, which
+  // is rendered within a Link, and if the default event behavior was allowed, clicking on the delete button
+  // in that context would cause the user to navigate to that Link's "to" prop
   return (
     <div className="confirmableDeleteButtonContainer" onClick={e => e.preventDefault()}>
       { isDeleting ? renderConfirmDeleteButtons() : renderInitialDeleteButton() }

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -21,7 +21,6 @@ export const PostProvider = props => {
     return fetch(`http://localhost:8088/posts/${id}`, {
       method: "DELETE"
     })
-      .then(getPosts);
   }
 
   return (

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -18,7 +18,9 @@ export const PostProvider = props => {
   };
 
   const deletePost = id => {
-    return fetch(`http://localhost:8088/posts/${id}`)
+    return fetch(`http://localhost:8088/posts/${id}`, {
+      method: "DELETE"
+    })
       .then(getPosts);
   }
 

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -17,11 +17,17 @@ export const PostProvider = props => {
       .then(setPosts);
   };
 
+  const deletePost = id => {
+    return fetch(`http://localhost:8088/posts/${id}`)
+      .then(getPosts);
+  }
+
   return (
     <PostContext.Provider
       value={{
         posts, getPosts,
-        getPostsByUserId
+        getPostsByUserId,
+        deletePost
       }}
     >
       {props.children}

--- a/src/components/posts/UserPostListItem.css
+++ b/src/components/posts/UserPostListItem.css
@@ -1,3 +1,8 @@
+.userPostList a {
+  color: #000;
+}
+
+.userPostList a,
 .userPostList a:hover {
   text-decoration: none;
 }
@@ -7,6 +12,7 @@
 .userPostListItem--col-right {
   display: flex;
   align-items: center;
+  line-height: 1;
 }
 
 .userPostListItem {
@@ -21,4 +27,17 @@
 .userPostListItem__title {
   font-size: 1.5rem;
   font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.userPostListItem__author {
+  align-self: flex-end;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+}
+
+.userPostListItem__author,
+.userPostListItem__category,
+.userPostListItem .confirmableDeleteButtonContainer {
+  color: #333;
 }

--- a/src/components/posts/UserPostListItem.css
+++ b/src/components/posts/UserPostListItem.css
@@ -1,3 +1,7 @@
+.userPostList a:hover {
+  text-decoration: none;
+}
+
 .userPostListItem,
 .userPostListItem--col-left,
 .userPostListItem--col-right {

--- a/src/components/posts/UserPostListItem.css
+++ b/src/components/posts/UserPostListItem.css
@@ -1,7 +1,3 @@
-.userPostList a {
-  color: #000;
-}
-
 .userPostList a,
 .userPostList a:hover {
   text-decoration: none;

--- a/src/components/posts/UserPostListItem.js
+++ b/src/components/posts/UserPostListItem.js
@@ -5,7 +5,7 @@ import "./UserPostListItem.css"
 
 export const UserPostListItem = props => {
   const { post } = props
-  const { id, title, user_id, category_id } = post
+  const { id, title, user, category } = post
 
   const { deletePost } = useContext(PostContext);
 
@@ -13,10 +13,10 @@ export const UserPostListItem = props => {
     <div className="userPostListItem">
       <div className="userPostListItem--col-left">
         <p className="userPostListItem__title">{title}</p>
-        <p className="userPostListItem__author">{user_id}</p>
+        <p className="userPostListItem__author">{user.first_name} {user.last_name}</p>
       </div>
       <div className="userPostListItem--col-right">
-        <p className="userPostListItem__category">{category_id}</p>
+        <p className="userPostListItem__category">{category.name}</p>
         <ConfirmableDeleteButton onDelete={() => deletePost(id)} />
       </div>
     </div>

--- a/src/components/posts/UserPostListItem.js
+++ b/src/components/posts/UserPostListItem.js
@@ -1,9 +1,13 @@
-import React from "react"
+import React, { useContext } from "react"
+import { ConfirmableDeleteButton } from "./ConfirmableDeleteButton"
+import { PostContext } from "./PostProvider"
 import "./UserPostListItem.css"
 
 export const UserPostListItem = props => {
   const { post } = props
-  const { title, user_id, category_id } = post
+  const { id, title, user_id, category_id } = post
+
+  const { deletePost } = useContext(PostContext);
 
   return (
     <div className="userPostListItem">
@@ -13,6 +17,7 @@ export const UserPostListItem = props => {
       </div>
       <div className="userPostListItem--col-right">
         <p className="userPostListItem__category">{category_id}</p>
+        <ConfirmableDeleteButton onDelete={() => deletePost(id)} />
       </div>
     </div>
   )

--- a/src/components/posts/UserPostListItem.js
+++ b/src/components/posts/UserPostListItem.js
@@ -7,7 +7,12 @@ export const UserPostListItem = props => {
   const { post } = props
   const { id, title, user, category } = post
 
-  const { deletePost } = useContext(PostContext);
+  const { deletePost, getPostsByUserId } = useContext(PostContext)
+
+  const handleDelete = id => {
+    deletePost(id)
+      .then(() => getPostsByUserId(localStorage.getItem('rare_user_id')))
+  }
 
   return (
     <div className="userPostListItem">
@@ -17,7 +22,7 @@ export const UserPostListItem = props => {
       </div>
       <div className="userPostListItem--col-right">
         <p className="userPostListItem__category">{category.name}</p>
-        <ConfirmableDeleteButton onDelete={() => deletePost(id)} />
+        <ConfirmableDeleteButton onDelete={() => handleDelete(id)} />
       </div>
     </div>
   )


### PR DESCRIPTION
# Description
Implemented `ConfirmableDeleteButton` component. It currently lives in the posts folder but it would work as a delete button with extra confirm step for any of our resources really.  Added this component to the `UserPostListItem`.
Implemented `deletePost` function in the `PostProvider`.

Fixes #64 #37 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [x] Login as a user that has created posts and navigate to /my-posts route
- [x] Confirm that, for each post the user has created, you see the ConfirmableDeleteButton component rendered in that list item
- [x] Confirm that if you click on this button, it will change over to being two buttons side-by-side, one of which says "Cancel" and the other of which says "Confirm Delete"
- [x] Confirm that if you click "Cancel", the button will return to how it was on page load and nothing else will happen
- [x] Confirm that if you hit "Confirm Delete", we will hit the API with a DELETE request for the post with that id, and consequently the post will be deleted. The list will automatically re-render to reflect this deletion, and you should no longer see that item in the list.
- [x] Verify that the list looks at least relatively nice. I did a little bit of CSS on the UserPostListItem as well.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings