### PR TITLE
Je dont derender post tag form until save complete

### DIFF
--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -10,13 +10,16 @@ export const PostTagForm = ({postId, endEditTags}) => {
 	const { tags, getTags } = useContext(TagContext)
 	const { getPostTagsByPostId, addPostTag, deletePostTag } = useContext(PostTagContext)
 	const [ thisPostTags, setThisPostTags ] = useState([]) 
-	const [ selectedPostTags, setSelectedPostTags ] = useState([]) 
+  const [ selectedPostTags, setSelectedPostTags ] = useState([]) 
+  const [ isSubmitting, setIsSubmitting ] = useState(false)
 
 	const handleChange = (val) => {
 		setSelectedPostTags(val)
 	}
 
 	const savePostTags = () => {
+    setIsSubmitting(true)
+
     // Iterate through the selected tag ids and save any tags that weren't initially selected.
     const addPostTagPromises = selectedPostTags
       .filter(selectedTagId => !thisPostTags.some(pt => pt.tag_id === selectedTagId))
@@ -36,6 +39,7 @@ export const PostTagForm = ({postId, endEditTags}) => {
 
     const allPromises = [ ...addPostTagPromises, ...deletePostTagPromises ]
     Promise.all(allPromises)
+      .then(() => setIsSubmitting(false))
       .then(endEditTags)
 	}
 
@@ -64,9 +68,10 @@ export const PostTagForm = ({postId, endEditTags}) => {
 			</ToggleButtonGroup>
 				<div className='post_tag_controls'>
 					<Button variant='secondary'
-					onClick={endEditTags}
+            onClick={endEditTags}
+            disabled={isSubmitting}
 					>Cancel</Button>
-					<Button onClick={savePostTags}>Save</Button>
+					<Button onClick={savePostTags} disabled={isSubmitting}>Save</Button>
 				</div>
 			</div>
 		</>

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -17,30 +17,26 @@ export const PostTagForm = ({postId, endEditTags}) => {
 	}
 
 	const savePostTags = () => {
-		
-		// Iterate through the selected tag ids and save any tags that weren't initially selected.
-		selectedPostTags.forEach( selectedTagId => {
-			const matchingPostTag = thisPostTags.find( pt => pt.tag_id === selectedTagId)
-			if (matchingPostTag === undefined) {
-				const newPostTag = {
-					post_id : postId,
-					tag_id : selectedTagId
-				}
-				addPostTag(newPostTag)
-			}
-		})
+    // Iterate through the selected tag ids and save any tags that weren't initially selected.
+    const addPostTagPromises = selectedPostTags
+      .filter(selectedTagId => !thisPostTags.some(pt => pt.tag_id === selectedTagId))
+      .map(selectedTagId => {
+        const newPostTag = {
+          post_id: postId,
+          tag_id: selectedTagId
+        };
 
-		// Iterate through the post tags that were initially selected, and delete the ones that were removed.
-		thisPostTags.forEach( pt => {
-			const matchingSelection = selectedPostTags.find( selectedTagId => selectedTagId === pt.tag_id )
-			if (matchingSelection === undefined) {
-				deletePostTag(pt.id)
-			}
+        return addPostTag(newPostTag)
+      })
 
-	})
-	endEditTags()
+    // Iterate through the post tags that were initially selected, and delete the ones that were removed.
+    const deletePostTagPromises = thisPostTags
+      .filter(pt => !selectedPostTags.some(selectedTagId => selectedTagId === pt.tag_id))
+      .map(pt => deletePostTag(pt.id))
 
-
+    const allPromises = [ ...addPostTagPromises, ...deletePostTagPromises ]
+    Promise.all(allPromises)
+      .then(endEditTags)
 	}
 
 	useEffect( () => {

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -20,9 +20,11 @@ export const PostTagForm = ({postId, endEditTags}) => {
 	const savePostTags = () => {
     setIsSubmitting(true)
 
-    // Iterate through the selected tag ids and save any tags that weren't initially selected.
-    const addPostTagPromises = selectedPostTags
-      .filter(selectedTagId => !thisPostTags.some(pt => pt.tag_id === selectedTagId))
+    // Filter down the currently-selected postTags in the form to only those that were not initially selected 
+    const postTagsToAdd = selectedPostTags.filter(selectedTagId => !thisPostTags.some(pt => pt.tag_id === selectedTagId))
+
+    // then call addPostTag for each of those, and store the resulting Promises in an array
+    const addPostTagPromises = postTagsToAdd
       .map(selectedTagId => {
         const newPostTag = {
           post_id: postId,
@@ -32,11 +34,14 @@ export const PostTagForm = ({postId, endEditTags}) => {
         return addPostTag(newPostTag)
       })
 
-    // Iterate through the post tags that were initially selected, and delete the ones that were removed.
-    const deletePostTagPromises = thisPostTags
-      .filter(pt => !selectedPostTags.some(selectedTagId => selectedTagId === pt.tag_id))
+    // Filter down the initial postTags to determine which ones are no longer selected (i.e., were "deselected" by the user)
+    const postTagsToDelete = thisPostTags.filter(pt => !selectedPostTags.some(selectedTagId => selectedTagId === pt.tag_id))
+
+    // then call deletePostTag for each of those, and store the resulting Promises in an array
+    const deletePostTagPromises = postTagsToDelete
       .map(pt => deletePostTag(pt.id))
 
+    // finally, combine the promises from the two arrays and, when all resolve, call "endEditTags" function
     const allPromises = [ ...addPostTagPromises, ...deletePostTagPromises ]
     Promise.all(allPromises)
       .then(() => setIsSubmitting(false))

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -59,7 +59,7 @@ export default (props) => {
         <Image src={post.image} fluid />
       </div>
       <p className="postDetail__content">{post.content}</p>
-			<PostTagManager postId={post.id} isPostAuthor={currentUser === post.user_id}/>
+      { post.id && <PostTagManager postId={post.id} isPostAuthor={currentUser === post.user_id}/> }
     </div>
   );
 };


### PR DESCRIPTION
# Description
Fixing an issue where the `PostTagManager` would display the `PostTagList` immediately after submission of the the `PostTagForm`, even if the asynchronous operations hadn't yet completed. Because the `PostTagList` is not using a state-based / context variable for its `postTags`, this would make it so that the `PostTagList` would not reflect the user's changes in the `PostTagForm` in most cases. This fix simply ensures that all of the asynchronous operations complete in the `PostTagForm` before the `PostTagList` is displayed again.

Fixing a second issue where, upon page load on any PostDetail page, a GET request would be sent to `/post_tags?post_id=undefined`, followed by a second GET request to the actual `/post_tags?post_id=<id of the post for the details page>`. This was because we were immediately rendering the `PostTagManager` in the `PostDetail` component, even before the actual post object returned from the GET request to the API, thereby passing a postId prop of `undefined` to the `PostTagManager` (which then passes it down to `PostTagList`) causing that component's dumb ass to try to ask the API for post tags for a post with ID of `undefined`. I fixed this by simply not rendering the `PostTagManager` in the `PostDetail` until there is a valid (truthy) `post.id`.

Fixes #110 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Go to a post detail page and click on the "Manage Tags" button.
- [ ] Make a lot of changes, selecting some tags and deselecting others.
- [ ] Click "Save" and ensure that when the `PostTagList` is displayed again, it reflects all of the changes that you made.
- [ ] Ensure also that the save / cancel buttons in the form are disabled after you click "Save" and remain that way until the async operations are complete and the component switches back over to the `PostTagList` (which prevents the user from double-clicking "Save")

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings