### PR TITLE
Fix post tag form appearance

### DIFF
--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -16,13 +16,18 @@ export const PostTagForm = ({postId, endEditTags}) => {
 
 	const handleChange = (changedTagId) => {
 		let newSelectedPostTags = []
+		//check if the tag is already in the list of selected tags
 		if (selectedPostTags.some(tagId => tagId === changedTagId )) {
+			// Remove the id of the tag from the list of selected tags
 			newSelectedPostTags = selectedPostTags.filter(tagId => tagId !== changedTagId)
 		}
 		else {
+			// Add the tag to the list of selected tags
 			selectedPostTags.push(changedTagId)
+			// Copy the selected tags array to a new variable so that state will update correctly
 			newSelectedPostTags = selectedPostTags.slice()
 		}
+		// Set component state, which will cause the component to re-render
 		setSelectedPostTags(newSelectedPostTags)
 	}
 

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -5,6 +5,7 @@ import ToggleButton from "react-bootstrap/ToggleButton"
 import { PostTagContext } from "./PostTagProvider"
 import Button from "react-bootstrap/esm/Button"
 import "./PostTagForm.css"
+import { Badge } from "react-bootstrap"
 
 export const PostTagForm = ({postId, endEditTags}) => {
 	const { tags, getTags } = useContext(TagContext)
@@ -13,8 +14,16 @@ export const PostTagForm = ({postId, endEditTags}) => {
   const [ selectedPostTags, setSelectedPostTags ] = useState([]) 
   const [ isSubmitting, setIsSubmitting ] = useState(false)
 
-	const handleChange = (val) => {
-		setSelectedPostTags(val)
+	const handleChange = (changedTagId) => {
+		let newSelectedPostTags = []
+		if (selectedPostTags.some(tagId => tagId === changedTagId )) {
+			newSelectedPostTags = selectedPostTags.filter(tagId => tagId !== changedTagId)
+		}
+		else {
+			selectedPostTags.push(changedTagId)
+			newSelectedPostTags = selectedPostTags
+		}
+		setSelectedPostTags(newSelectedPostTags)
 	}
 
 	const savePostTags = () => {
@@ -48,6 +57,8 @@ export const PostTagForm = ({postId, endEditTags}) => {
       .then(endEditTags)
 	}
 
+
+	
 	useEffect( () => {
 		getTags()
 		getPostTagsByPostId(postId)
@@ -59,26 +70,35 @@ export const PostTagForm = ({postId, endEditTags}) => {
 
 	return (
 		<>
-			<div>
-			<ToggleButtonGroup 
-			type="checkbox" 
-			value={selectedPostTags} 
-			className="mb-2"
-			onChange={handleChange}>
+			
 				{
 					tags.map( tag => {
-						return ( <ToggleButton value={tag.id} key={tag.id}>{tag.name}</ToggleButton> )
+						return ( 
+						<Button pill 
+						variant={ 
+							selectedPostTags.some(tagId => tagId === tag.id)
+							? 'primary'
+							: 'secondary'
+							}
+							onClick={endEditTags}
+							disabled={isSubmitting}
+						key={tag.id}
+						onClick={evt => handleChange(tag.id)}
+						>
+							{tag.name}
+						</Button>)
 					})					
 				}
-			</ToggleButtonGroup>
 				<div className='post_tag_controls'>
 					<Button variant='secondary'
             onClick={endEditTags}
-            disabled={isSubmitting}
-					>Cancel</Button>
+						disabled={isSubmitting}
+						>
+							Cancel
+						</Button>
 					<Button onClick={savePostTags} disabled={isSubmitting}>Save</Button>
 				</div>
-			</div>
+			
 		</>
 	)
 

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -1,11 +1,8 @@
 import React, { useContext, useEffect, useState } from "react"
 import { TagContext } from "../tags/TagProvider"
-import ToggleButtonGroup from "react-bootstrap/ToggleButtonGroup"
-import ToggleButton from "react-bootstrap/ToggleButton"
 import { PostTagContext } from "./PostTagProvider"
 import Button from "react-bootstrap/esm/Button"
 import "./PostTagForm.css"
-import { Badge } from "react-bootstrap"
 
 export const PostTagForm = ({postId, endEditTags}) => {
 	const { tags, getTags } = useContext(TagContext)

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -21,7 +21,7 @@ export const PostTagForm = ({postId, endEditTags}) => {
 		}
 		else {
 			selectedPostTags.push(changedTagId)
-			newSelectedPostTags = selectedPostTags
+			newSelectedPostTags = selectedPostTags.slice()
 		}
 		setSelectedPostTags(newSelectedPostTags)
 	}
@@ -73,17 +73,17 @@ export const PostTagForm = ({postId, endEditTags}) => {
 			
 				{
 					tags.map( tag => {
+						const tagSelected = selectedPostTags.some(tagId => tagId === tag.id)
 						return ( 
 						<Button pill 
 						variant={ 
-							selectedPostTags.some(tagId => tagId === tag.id)
+							tagSelected
 							? 'primary'
 							: 'secondary'
 							}
-							onClick={endEditTags}
 							disabled={isSubmitting}
-						key={tag.id}
-						onClick={evt => handleChange(tag.id)}
+							key={tag.id}
+							onClick={evt => handleChange(tag.id)}
 						>
 							{tag.name}
 						</Button>)

--- a/src/components/postTags/PostTagForm.js
+++ b/src/components/postTags/PostTagForm.js
@@ -80,7 +80,9 @@ export const PostTagForm = ({postId, endEditTags}) => {
 					tags.map( tag => {
 						const tagSelected = selectedPostTags.some(tagId => tagId === tag.id)
 						return ( 
-						<Button pill 
+						<Button 
+						style={{margin:"0 10px"}}
+						size='sm' 
 						variant={ 
 							tagSelected
 							? 'primary'


### PR DESCRIPTION
# Description
Fix the issue where post tags still look like the are selected, even when they are just focused. 
Style the buttons on the post tag form as buttons, to make them more like the badge display of tags.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Check that the post tag form now displays as a list of buttons
- [ ] Check that when post tags are de-selected, they immediately render in grey
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings