### PR TITLE
add dummy / placeholder onDelete handlers

### DIFF
--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -37,7 +37,7 @@ export default (props) => {
               <Category category={c} key={c.id} />
               </Col>
               <Col className="d-flex justify-content-end m-2">
-                <ConfirmableDeleteButton />
+                <ConfirmableDeleteButton onDelete={() => alert('delete not implemented')} />
                 <Button>Edit</Button>
               </Col>
               </Row>

--- a/src/components/tags/TagList.js
+++ b/src/components/tags/TagList.js
@@ -37,7 +37,7 @@ export default (props) => {
 							<Tag tag={t} key={t.id} />
 						</Col>
 						<Col className="d-flex justify-content-end m-2">
-							<ConfirmableDeleteButton />
+							<ConfirmableDeleteButton onDelete={() => alert('delete not implemented')} />
 							<Button>Edit</Button>
 						</Col>
 						</Row>


### PR DESCRIPTION
# Description
Fixes an issue where clicking `Confirm Delete` in either the Category or Tag list pages would throw an error. The `ConfirmableDeleteButton` expects to be passed an `onDelete` function that it calls when the user actually clicks "Confirm Delete" and because no such function was passed, confirming would throw an error when trying to invoke the function. Please don't blame the `ConfirmableDeleteButton` it is a fine component.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Click "Confirm Delete" on the `ConfirmableDeleteButton` in both the `TagList` and the `CategoryList` components, and verify that no error is thrown (I made it just alert some placeholder text for now)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings