### PR TITLE
added auth token to getPostById in provider, and now have post details displaying

### DIFF
--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 import React, { useContext, useState, useEffect } from "react";
-import { Image, Badge, Row, Col } from "react-bootstrap";
+import { Image, Badge, Row, Col, Button } from "react-bootstrap";
 import { ConfirmableDeleteButton } from "./ConfirmableDeleteButton";
 import { PostContext } from "./PostProvider";
 import { PostTagManager } from "../postTags/PostTagManager";
@@ -13,7 +13,7 @@ export default (props) => {
   const { getPostById, deletePost, getPosts } = useContext(PostContext);
   const [post, setPost] = useState({ category: {}, user: {} });
   const currentUser = parseInt(localStorage.getItem("rare_user_id"));
-  const date = moment(post.publication_time + 86400000).format(
+  const date = moment(post.publication_time).format(
     "dddd, MMMM Do YYYY"
   );
   const handleDeleteButtonClick = () => {
@@ -55,7 +55,7 @@ export default (props) => {
         </Col>
         <Col className="d-flex justify-content-end">
           <p className="postDetail__category">
-            <Badge variant="info">{post.category.name}</Badge>
+            <Badge variant="info">{post.category.label}</Badge>
           </p>
         </Col>
       </Row>
@@ -64,27 +64,15 @@ export default (props) => {
         <Image src={post.image} fluid />
       </Row>
       <Row className="justify-content-center my-4">
+      <Button variant="secondary"
+      type="submit"
+      className="ml-2"
+      onClick={e=> props.history.push(`posts/${post.id}/comments`)}
+      >View Comments</Button>
+      </Row>
+      <Row className="justify-content-center my-4">
         <p className="postDetail__content w-75">{post.content}</p>
       </Row>
-
-      { post.id && 
-        <>
-          <PostTagManager postId={post.id} isPostAuthor={currentUser === post.user_id} /> 
-
-          <h3 className="text-center my-3">Comments</h3>
-          <Row className="my-4">
-            <Col lg="6" sm="10" className="mx-auto">
-              <CommentList postId={post.id} />
-            </Col>
-          </Row>
-
-          <Row>
-            <Col lg="6" sm="10" className="mx-auto">
-              <CommentForm postId={post.id} />
-            </Col>
-          </Row>
-        </>
-      }
     </div>
   );
 };

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -67,7 +67,7 @@ export default (props) => {
       <Button variant="secondary"
       type="submit"
       className="ml-2"
-      onClick={e=> props.history.push(`posts/${post.id}/comments`)}
+      onClick={e=> props.history.push(`/posts/${post.id}/comments`)}
       >View Comments</Button>
       </Row>
       <Row className="justify-content-center my-4">

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -17,7 +17,13 @@ export const PostProvider = (props) => {
   };
 
   const getPostById = (postId) => {
-    return fetch(`http://localhost:8000/posts/${postId}`).then((res) =>
+    return fetch(`http://localhost:8000/posts/${postId}`, {
+      headers: {
+        Authorization: `Token ${localStorage.getItem("rare_user_token")}`,
+        "Content-Type": "application/json",   
+      }
+    })
+    .then((res) =>
       res.json()
     );
   };


### PR DESCRIPTION
# Description
Added the auth token header to the posts data provider.  I fixed up the code for posts detail so the dat is coming in formatted correctly, as well as all the content pertaining to a post object. I removed the comments list as well as the form.  Now there is a View comments button that re routes the url.

Fixes #184 
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] `git fetch --all`
- [ ] `git checkout mt-post-details`
- [ ] Log in to any user
- [ ] go to all posts and click on one
- [ ] verify all the content is being displayed correctly
- [ ] click the `View Comments` button and it should change the URL to 
`/posts/{postId of the clicked post}/comments`
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings