### PR TITLE
fixed category to show the label instead of blank for all posts

### DIFF
--- a/src/components/posts/PostListItem.js
+++ b/src/components/posts/PostListItem.js
@@ -16,7 +16,7 @@ export const PostListItem = props => {
       </Col>
       <Col sm="2" className="d-flex justify-content-end">
         <Badge variant="info">
-          <span className="postListItem__categoryName">{category.name}</span>
+          <span className="postListItem__categoryName">{category.label}</span>
         </Badge>
       </Col>
     </Row>


### PR DESCRIPTION
# Description
Changed category.name to category.label so the categories get displayed properly in the all posts section.

fixes #177  

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] `git fetch --all`
- [ ] `git fetch mt-get-all-posts`
- [ ] log on and make sure the categories are being displayed on the post list next to the title and authors
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings