### PR TITLE
Create image post list item

### DIFF
--- a/src/components/posts/ImagePostListItem.js
+++ b/src/components/posts/ImagePostListItem.js
@@ -9,7 +9,6 @@ export const ImagePostListItem = props => {
   const { post } = props
   const { id, title, user, publication_date, image_url } = post
   const readableDate = (new Date(publication_date + 'T00:00:00')).toLocaleDateString('en-Us')
-
   const { deletePost, getPostsByUserId } = useContext(PostContext)
 
   const handleDelete = id => {
@@ -39,10 +38,15 @@ export const ImagePostListItem = props => {
         <Col sm="6" className="d-flex justify-content-end">
           <div>Reactions Placeholder</div>
         </Col>
-        <Col sm="3" className="d-flex justify-content-end" onClick={e => e.preventDefault()}>
-          <EditPostButton postId={id} />
-          <ConfirmableDeleteButton onDelete={() => handleDelete(id)} />
-        </Col>
+        {
+          // Conditionally render the edit and delete buttons based on whether the viewer is the author)
+          (post.user.id === parseInt(localStorage.getItem('rare_user_id')))
+          ? <Col sm="3" className="d-flex justify-content-end" onClick={e => e.preventDefault()}>
+              <EditPostButton postId={id} />
+              <ConfirmableDeleteButton onDelete={() => handleDelete(id)} />
+            </Col>
+          : <></>
+        }
       </Row>
     </div>
   )

--- a/src/components/posts/ImagePostListItem.js
+++ b/src/components/posts/ImagePostListItem.js
@@ -5,7 +5,7 @@ import { PostContext } from "./PostProvider"
 import { Row, Col, Image } from "react-bootstrap"
 import "./PostListItem.css"
 
-export const UserPostListItem = props => {
+export const ImagePostListItem = props => {
   const { post } = props
   const { id, title, user, publication_date, image_url } = post
   const readableDate = (new Date(publication_date + 'T00:00:00')).toLocaleDateString('en-Us')

--- a/src/components/posts/UserPostList.js
+++ b/src/components/posts/UserPostList.js
@@ -2,7 +2,7 @@ import React, { useEffect, useContext } from "react"
 import { Link } from "react-router-dom"
 import ListGroup from "react-bootstrap/ListGroup"
 import { PostContext } from "./PostProvider"
-import { UserPostListItem } from "./UserPostListItem"
+import { ImagePostListItem } from "./ImagePostListItem"
 
 export const UserPostList = props => {
   const { posts, getPostsByUserId } = useContext(PostContext)
@@ -20,7 +20,7 @@ export const UserPostList = props => {
       <ListGroup>
         { posts.map(post => (
           <ListGroup.Item action key={post.id} as={Link} to={`/posts/${post.id}`}>
-            <UserPostListItem post={post} />
+            <ImagePostListItem post={post} />
           </ListGroup.Item>
         )).reverse()}
       </ListGroup>


### PR DESCRIPTION
# Description
Users should be able to click on a category, and see posts associated with that category, as well as a preview of the post image. To make this possible, we are renaming UserPostListItem to ImagePostListItem, and conditionally displaying the edit and delete buttons based on whether the post viewer is the post owner.
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Verify that posts with images still render with images, edit and delete buttons in the myPosts view
- [ ] There isn't currently a way to view a post with image that doesn't belong to the current user ... so that part of the change will have to be verified later.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings