### PR TITLE
Je approve posts

### DIFF
--- a/src/components/posts/ApprovePostToggler.js
+++ b/src/components/posts/ApprovePostToggler.js
@@ -1,14 +1,24 @@
-import React from "react"
+import React, { useContext, useState } from "react"
+import { PostContext } from "./PostProvider"
 
 export const ApprovePostToggler = props => {
   const { postId, isApproved } = props;
 
+  const [ isSubmitting, setIsSubmitting ] = useState(false)
+
+  const { updatePostApproval } = useContext(PostContext)
+
   const handleToggleApproval = () => {
-    
+    setIsSubmitting(true)
+    const updatedIsApproved = !isApproved
+
+    updatePostApproval(postId, updatedIsApproved)
+      .then(() => setIsSubmitting(false))
   }
 
   return (
     <input type="checkbox" 
+      disabled={isSubmitting}
       name="approve_post" 
       checked={isApproved}
       onClick={handleToggleApproval} />

--- a/src/components/posts/ApprovePostToggler.js
+++ b/src/components/posts/ApprovePostToggler.js
@@ -25,6 +25,6 @@ export const ApprovePostToggler = props => {
       disabled={isSubmitting}
       name="approve_post" 
       checked={isApproved}
-      onClick={handleToggleApproval} />
+      onChange={handleToggleApproval} />
   )
 }

--- a/src/components/posts/ApprovePostToggler.js
+++ b/src/components/posts/ApprovePostToggler.js
@@ -1,0 +1,16 @@
+import React from "react"
+
+export const ApprovePostToggler = props => {
+  const { postId, isApproved } = props;
+
+  const handleToggleApproval = () => {
+    
+  }
+
+  return (
+    <input type="checkbox" 
+      name="approve_post" 
+      checked={isApproved}
+      onClick={handleToggleApproval} />
+  )
+}

--- a/src/components/posts/ApprovePostToggler.js
+++ b/src/components/posts/ApprovePostToggler.js
@@ -1,9 +1,13 @@
 import React, { useContext, useState } from "react"
 import { PostContext } from "./PostProvider"
 
+/**
+ * Component rendering as a checkbox that allows user to toggle the "approved" status of a post
+ */
 export const ApprovePostToggler = props => {
   const { postId, isApproved } = props;
 
+  // state used to disable the input while submitting to avoid double-clicks
   const [ isSubmitting, setIsSubmitting ] = useState(false)
 
   const { updatePostApproval } = useContext(PostContext)

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -48,7 +48,10 @@ export const PostList = props => {
                 <th>Date</th>
                 <th>Category</th>
                 <th>Tags</th>
-                { isAdmin && <th>Approved</th> }
+                { 
+                  // conditionally render Approved table header based on truthiness of isAdmin
+                  isAdmin && <th>Approved</th> 
+                }
               </tr>
             </thead>
             <tbody>
@@ -57,7 +60,7 @@ export const PostList = props => {
                   const { id, title, user, publication_date, category, tags } = post;
                   const readableDate = (new Date(publication_date + 'T00:00:00')).toLocaleDateString('en-US')
 
-                  // computer user permissions for delete/edit 
+                  // compute user permissions for delete/edit 
                   // (admin can delete/edit any, author can only delete/edit their own)
                   const canDeleteAndEdit = isAdmin ||
                     user.id === parseInt(localStorage.getItem('rare_user_id')) 
@@ -66,6 +69,7 @@ export const PostList = props => {
                     <tr key={id} className="position-relative">
                       <td>
                         {
+                          // conditionally render edit/delete controls based on truthiness of canDeleteAndEdit
                           canDeleteAndEdit &&
                           <div className="d-flex">
                             <EditPostButton postId={id} />
@@ -87,6 +91,7 @@ export const PostList = props => {
                         ))}
                       </td>
                       {
+                        // conditionally render post approval control based on truthiness of isAdmin
                         isAdmin &&
                         <td>
                           <ApprovePostToggler postId={post.id}

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -6,6 +6,7 @@ import { MdAdd } from "react-icons/md"
 import { PostContext } from "./PostProvider"
 import EditPostButton from "./EditPostButton"
 import { ConfirmableDeleteButton } from "./ConfirmableDeleteButton"
+import { ApprovePostToggler } from "./ApprovePostToggler"
 import Category from "../categories/Category"
 import Tag from "../tags/Tag"
 
@@ -20,6 +21,8 @@ export const PostList = props => {
     }, [])
 
     const history = useHistory()
+
+    const isAdmin = localStorage.getItem('is_admin')
 
     const handleDelete = postId => {
       deletePost(postId)
@@ -45,6 +48,7 @@ export const PostList = props => {
                 <th>Date</th>
                 <th>Category</th>
                 <th>Tags</th>
+                { isAdmin && <th>Approved</th> }
               </tr>
             </thead>
             <tbody>
@@ -52,11 +56,17 @@ export const PostList = props => {
                 posts.map(post => {
                   const { id, title, user, publication_date, category, tags } = post;
                   const readableDate = (new Date(publication_date + 'T00:00:00')).toLocaleDateString('en-US')
+
+                  // computer user permissions for delete/edit 
+                  // (admin can delete/edit any, author can only delete/edit their own)
+                  const canDeleteAndEdit = isAdmin ||
+                    user.id === parseInt(localStorage.getItem('rare_user_id')) 
+
                   return (
                     <tr key={id} className="position-relative">
                       <td>
                         {
-                          user.id === parseInt(localStorage.getItem('rare_user_id')) &&
+                          canDeleteAndEdit &&
                           <div className="d-flex">
                             <EditPostButton postId={id} />
                             <ConfirmableDeleteButton 
@@ -76,6 +86,13 @@ export const PostList = props => {
                             <Tag key={t.id} tag={t} />
                         ))}
                       </td>
+                      {
+                        isAdmin &&
+                        <td>
+                          <ApprovePostToggler postId={post.id}
+                            isApproved={post.approved} />
+                        </td>
+                      }
                     </tr>
                   )
                 })

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -89,6 +89,20 @@ export const PostProvider = (props) => {
     });
   };
 
+  const updatePostApproval = (id, approved) => {
+    const updateObject = { approved }
+
+    return fetch(`http://localhost:8000/posts/${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Token ${localStorage.getItem("rare_user_token")}`
+      },
+      body: JSON.stringify(updateObject)
+    })
+      .then(getPosts)
+  }
+
   return (
     <PostContext.Provider
       value={{
@@ -100,6 +114,7 @@ export const PostProvider = (props) => {
         createPost,
         updatePost,
         getPostsByCategoryId,
+        updatePostApproval
       }}
     >
       {props.children}


### PR DESCRIPTION
# Description
Adding the ability for an admin user to approve / disapprove a post. Also added the logic to display edit+delete buttons on all posts in the PostList if the user is an admin.

Fixes #238 Fixes #164 

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Log in as the admin user and verify that on the `PostList` component (currently just at `/` route) the admin user has the option to edit or delete any of the posts, and also has a new column in each row of the table where they can approve / unapprove a post.
- [ ] Verify that it looks like the wireframe specifies.
- [ ] Verify that if the admin clicks on a checkbox, that the approved status of the post will be toggled over to the opposite of what it is currently at. This will automatically send a `PATCH` to the API immediately on click.
- [ ] Log out of the admin and log in as a non-admin user, and verify that you do not see the approve checkbox control, and that the user can only edit/delete their own posts.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings