### PR TITLE
Je posts by subscription

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -7,6 +7,7 @@ import { UserPostList } from "./posts/UserPostList";
 import { TagProvider } from "./tags/TagProvider";
 import PostDetail from "./posts/PostDetail";
 import { PostList } from "./posts/PostList";
+import { SubscribedPostList } from "./posts/SubscribedPostList"
 import { CommentProvider } from "./comments/CommentProvider";
 import { CategoryManager } from "./categories/CategoryManager";
 import { CommentList } from "./comments/CommentList";
@@ -41,7 +42,7 @@ export const ApplicationViews = () => {
         </PostProvider>
         <PostProvider>
           <CategoryProvider>
-            <Route exact path="/" component={PostList} />
+            <Route exact path="/" component={SubscribedPostList} />
           </CategoryProvider>
         </PostProvider>
 

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -35,15 +35,14 @@ export const ApplicationViews = () => {
         <PostProvider>
           <CategoryProvider>
             <TagProvider>
+              <Route exact path="/" component={SubscribedPostList} />
+
+              <Route exact path="/posts" component={PostList} />
+
               <Route path="/posts/create" component={PostForm} />
 
               <Route path="/posts/edit/:postId" component={PostForm} />
             </TagProvider>
-          </CategoryProvider>
-        </PostProvider>
-        <PostProvider>
-          <CategoryProvider>
-            <Route exact path="/" component={SubscribedPostList} />
           </CategoryProvider>
         </PostProvider>
 

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -15,7 +15,7 @@ export const NavBar = (props) => {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav container ">
           <Nav className="mr-auto container-fluid">
-            <Button variant="outline-primary" className="mx-2 my-1" onClick={() => props.history.push("/")}>All Posts</Button>
+            <Button variant="outline-primary" className="mx-2 my-1" onClick={() => props.history.push("/posts")}>All Posts</Button>
             <Button variant="outline-primary" className="mx-2 my-1" onClick={() => props.history.push("/my-posts")}>My Posts</Button>
             <Button variant="outline-primary" className="mx-2 my-1" onClick={() => props.history.push("/categories")}>Category Manager</Button>
             <Button variant="outline-primary" className="mx-2 my-1" onClick={() => props.history.push("/tags")}>Tag Manager</Button>

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -51,6 +51,16 @@ export const PostProvider = (props) => {
       .then(setPosts);
   };
 
+  const getSubscribedPosts = () => {
+    return fetch('http://localhost:8000/posts?subscribed=true', {
+      headers: {
+        "Authorization": `Token ${localStorage.getItem("rare_user_token")}`
+      }
+    })
+      .then(res => res.json())
+      .then(setPosts);
+  };
+
   const createPost = (post) => {
     return fetch(`http://localhost:8000/posts`, {
       method: "POST",
@@ -110,6 +120,7 @@ export const PostProvider = (props) => {
         getPosts,
         getPostById,
         getPostsByUserId,
+        getSubscribedPosts,
         deletePost,
         createPost,
         updatePost,

--- a/src/components/posts/SubscribedPostList.js
+++ b/src/components/posts/SubscribedPostList.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useContext } from "react"
+import { Link } from "react-router-dom"
+import { ListGroup } from "react-bootstrap"
+
+import { PostContext } from "./PostProvider"
+import { ImagePostListItem } from "./ImagePostListItem"
+
+export const SubscribedPostList = () => {
+  const { posts, getSubscribedPosts } = useContext(PostContext)
+
+  useEffect(() => {
+    getSubscribedPosts()
+  }, [])
+
+  return (
+    <div className="postList">
+      <ListGroup>
+        { posts.map(post => (
+          <ListGroup.Item action key={post.id} as={Link} to={`/posts/${post.id}`}>
+            <ImagePostListItem post={post} />
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
+    </div>
+  )
+}


### PR DESCRIPTION
# Description
This PR adds the new `SubscribedPostList` which just renders a list of posts by authors the user is currently subscribed to. It sets this page at the `/` route, and moves the `PostList` to `/posts`.

Fixes #157 #250 #251 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Go to http://localhost:3000/ - this is now the new home page that will only show posts by authors the logged-in user is subscribed to.
- [ ] Create a subscription (currently this can only be done by `POST` to http://localhost:8000/subscriptions) to some author that has created posts, and verify that their posts now show up in this view.

For more detailed testing steps, you could step through the testing steps in the matching server-side PR and ensure that the client behaves as expected for each step in that PR testing: https://github.com/NSS-Day-Cohort-42/news_hounds_django_server/pull/30

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings