### PR TITLE
Conditionally rendering edit/delete buttons on comments based on permission criteria

### DIFF
--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -27,48 +27,40 @@ export const CommentList = (props) => {
       >
         <ListGroup>
           {comments.map((c) => {
-            if (
-              parseInt(localStorage.getItem("rare_user_id")) === c.author.id
-            ) {
-              return (
-                <div>
-                  <ListGroup.Item key={c.id}>
-                    <Row className="justify-content-between">
-                      <h1>subject: {c.subject}</h1>
-                      <div className="d-flex">
+            const isOwnComment = c.author.id === parseInt(localStorage.getItem("rare_user_id"))
+            
+            const canEdit = isOwnComment
+            const canDelete = isOwnComment || localStorage.getItem('is_admin')
+
+            return (
+              <div>
+                <ListGroup.Item key={c.id}>
+                  <Row className="justify-content-between">
+                    <h1>subject: {c.subject}</h1>
+                    <div className="d-flex">
+                      { canEdit && 
                         <ConfirmableEditCommentButton
                           comment={c}
                           postId={parseInt(props.match.params.postId)}
                         />
+                      }
+
+                      { canDelete &&
                         <ConfirmableDeleteButton
                           prompt="Are you sure you want to delete this comment?"
                           onDelete={() => confirmDelete(c.id, props)}
                         />
-                      </div>
-                    </Row>
-                    <h4>{c.content}</h4>
-                    <h4>
-                      {new Date(c.created_on).toLocaleDateString("en-Us")}
-                    </h4>
-                    <h4>{c.author && c.author.username}</h4>
-                  </ListGroup.Item>
-                </div>
-              );
-            } else {
-              return (
-                <div>
-                  <ListGroup.Item key={c.id}>
-                    <div comment={c.content} />
-                    <h1>subject: {c.subject}</h1>
-                    <h4>{c.content}</h4>
-                    <h4>
-                      {new Date(c.created_on).toLocaleDateString("en-Us")}
-                    </h4>
-                    <h4>{c.author && c.author.username}</h4>
-                  </ListGroup.Item>
-                </div>
-              );
-            }
+                      }
+                    </div>
+                  </Row>
+                  <h4>{c.content}</h4>
+                  <h4>
+                    {new Date(c.created_on).toLocaleDateString("en-Us")}
+                  </h4>
+                  <h4>{c.author && c.author.username}</h4>
+                </ListGroup.Item>
+              </div>
+            );
           })}
         </ListGroup>
       </div>


### PR DESCRIPTION
# Description
This PR adds logic to the `CommentList` that conditionally renders the delete and edit buttons based on permission criteria of the active user. Specifically:

- An author can edit and delete their own comments
- An admin can delete any comment, and can edit only their own comments

Fixes #267 
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Log in as a non-admin user and go to a post's comments. Create a comment and verify that you see the edit and delete controls for the comment.
- [ ] Log in as an admin and go to that same post's comments. Verify that you only see a delete control for the other comment you just made as the non-admin user. Then make a comment and verify you can see both the edit and delete controls.
- [ ] Log back in as the first user you logged in as and go back to that post's comments. Verify that you cannot see any delete or edit controls on the admin's comment.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings…omment's author and user's admin status