### PR TITLE
Gs detail page tweaks

### DIFF
--- a/src/components/posts/PostDetail.css
+++ b/src/components/posts/PostDetail.css
@@ -6,3 +6,7 @@
 .postDetail__category {
   font-size: 1.5rem;
 }
+
+.postDetail__button {
+  background: transparent
+}

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -8,12 +8,14 @@ import "./PostDetail.css";
 import { PostTagList } from "../postTags/PostTagList";
 import ReactionList from "../reactions/ReactionList";
 import PostReactions from "./PostReactions";
+import { Link } from "react-router-dom";
 
 export default (props) => {
   const { getPostById, deletePost, getPosts } = useContext(PostContext);
   const [post, setPost] = useState({ category: {}, user: {} });
   const currentUser = parseInt(localStorage.getItem("rare_user_id"));
   const date = moment(post.publication_time).format("dddd, MMMM Do YYYY");
+  const userIsAdmin = localStorage.getItem("is_admin") ? true : false
   const handleDeleteButtonClick = () => {
     deletePost(post.id)
       .then(() => {
@@ -40,10 +42,11 @@ export default (props) => {
           <h2 className="postDetail__title font-weight-bold">{post.title}</h2>
         </Col>
         <Col xl="4" lg="5" sm="12">
-          {currentUser === post.user.id && (
+          {((currentUser === post.user.id) || (userIsAdmin)) && (
             <Row className="justify-content-end">
               <ConfirmableDeleteButton onDelete={handleDeleteButtonClick} />
               <EditPostButton postId={post.id} />
+              {(localStorage.getItem("is_admin") && post.approved) ? <div> Approved</div> : localStorage.getItem("is_admin") ?  <p>Not Approved</p> : <></>}
             </Row>
           )}
         </Col>
@@ -65,10 +68,11 @@ export default (props) => {
       </Row>
 
       <Row>
-        <Col className="d-flex justify-content-between">
-          <p className="postDetail__username">{post.user.username}</p>
+
+        <Col className="d-flex justify-content-between align-items-center sm-6">
+          <p className="postDetail__username">By: <Link to={`/profiles/${post.user.id}`}>{post.user.username}</Link></p>
           <Button
-            variant="secondary"
+            variant="outline-dark"
             type="submit"
             className="ml-2"
             onClick={(e) => props.history.push(`/posts/${post.id}/comments`)}
@@ -76,14 +80,17 @@ export default (props) => {
             View Comments
           </Button>
         </Col>
-        {post.id && (
-          <ReactionList
-            postReactions={post.reactions}
-            userReactions={post.user_reactions}
-            postId={post.id}
-            handleReaction={handleReaction}
-          />
-        )}
+
+        <Col className="sm-6">
+          {post.id && (
+            <ReactionList
+              postReactions={post.reactions}
+              userReactions={post.user_reactions}
+              postId={post.id}
+              handleReaction={handleReaction}
+            />
+          )}
+        </Col>
       </Row>
       <Row className="justify-content-center my-4">
         <p className="postDetail__content w-75">{post.content}</p>

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 import React, { useContext, useState, useEffect } from "react";
-import { Image, Badge, Row, Col, Button } from "react-bootstrap";
+import { Image, Badge, Row, Col, Button, Container } from "react-bootstrap";
 import { ConfirmableDeleteButton } from "./ConfirmableDeleteButton";
 import { PostContext } from "./PostProvider";
 import EditPostButton from "./EditPostButton";
@@ -25,8 +25,8 @@ export default (props) => {
   };
 
   const handleReaction = (postId) => {
-      getPostById(postId).then(setPost)    
-  }
+    getPostById(postId).then(setPost);
+  };
 
   useEffect(() => {
     const postId = parseInt(props.match.params.postId);
@@ -34,7 +34,7 @@ export default (props) => {
   }, []);
 
   return (
-    <div className="postDetail">
+    <Container>
       <Row>
         <Col xl="8" lg="7" sm="12">
           <h2 className="postDetail__title font-weight-bold">{post.title}</h2>
@@ -51,7 +51,6 @@ export default (props) => {
 
       <Row className="justify-content-between">
         <Col>
-          <p className="postDetail__username">{post.user.username}</p>
           <p className="postDetail__date">{date}</p>
         </Col>
         <Col className="d-flex justify-content-end">
@@ -64,21 +63,32 @@ export default (props) => {
       <Row className="justify-content-center my-4">
         <Image src={post.image_url} fluid />
       </Row>
-      <Row className="justify-content-center my-4">
-        <Button
-          variant="secondary"
-          type="submit"
-          className="ml-2"
-          onClick={(e) => props.history.push(`/posts/${post.id}/comments`)}
-        >
-          View Comments
-        </Button>
+
+      <Row>
+        <Col className="d-flex justify-content-between">
+          <p className="postDetail__username">{post.user.username}</p>
+          <Button
+            variant="secondary"
+            type="submit"
+            className="ml-2"
+            onClick={(e) => props.history.push(`/posts/${post.id}/comments`)}
+          >
+            View Comments
+          </Button>
+        </Col>
+        {post.id && (
+          <ReactionList
+            postReactions={post.reactions}
+            userReactions={post.user_reactions}
+            postId={post.id}
+            handleReaction={handleReaction}
+          />
+        )}
       </Row>
       <Row className="justify-content-center my-4">
         <p className="postDetail__content w-75">{post.content}</p>
       </Row>
-      {post.id && <ReactionList postReactions={post.reactions} userReactions={post.user_reactions} postId={post.id} handleReaction={handleReaction} />}
       {post.id && <PostTagList postTags={post.tags} />}
-    </div>
+    </Container>
   );
 };

--- a/src/components/reactions/ReactionList.js
+++ b/src/components/reactions/ReactionList.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Row } from "react-bootstrap";
+import { Row, Image } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import { PostContext } from "../posts/PostProvider";
 import { ReactionContext } from "./ReactionProvider";
@@ -62,14 +62,14 @@ export default (props) => {
 
         return (
           <article className="reaction">
-            <div className="reaction--count">{r.count}</div>
             <button
               disabled={submitting}
               className="reaction--image"
               onClick={() => handleReactionClick(userHasReacted, r.id)}
             >
-              <img src={r.img} />
+              <Image src={r.img} />
             </button>
+            <div className="reaction--count">{r.count}</div>
           </article>
         );
       })}

--- a/src/components/reactions/reactions.css
+++ b/src/components/reactions/reactions.css
@@ -1,5 +1,7 @@
 .reactions {
-    display: flex
+    display: flex;
+    border: 2px solid black;
+    border-radius: 20px;
 }
 
 .reaction {
@@ -10,4 +12,16 @@
 .reaction--image {
     border: none;
     background: none;
+}
+
+.btn-outline-dark {
+    color:black !important;
+    border-color: black !important;
+    border-width: 2px !important
+}
+
+.btn-outline-dark:hover {
+    color:white !important;
+    border-color: white !important;
+    border-width: 2px !important
 }


### PR DESCRIPTION
# Description
scooches just a lil bit closer to the wireframe for postdetail view. admin can see "approved" or "not approved" on each post detail page and also edit/delete controls as per the wireframe
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
- [ ] log in a me@me.me (not an admin), open a post detail and make sure you can see edit and delete controls on your post but not other
- [ ] log in as admin and make sure you can see edit and delete controls for every post detail as well as an "approved" and "not approved" indicator 
- [ ] bottom of the page is a lil more like the wireframe although im not bootstrap/cssy enough to figure out how to get the damn tags on the side. oh yeah clicking an authors name takes you to their profile
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings